### PR TITLE
Add Firo peers

### DIFF
--- a/src/electrumx/lib/coins.py
+++ b/src/electrumx/lib/coins.py
@@ -2629,7 +2629,10 @@ class Firo(Coin):
     DAEMON = daemon.FiroMtpDaemon
     DESERIALIZER = lib_tx_firo.DeserializerFiro
     PEERS = [
-        'electrum.polispay.com'
+        'electrumx01.firo.org s t',
+        'electrumx02.firo.org s t',
+        'electrumx03.firo.org s t',
+        'electrumx.firo.org s t',
     ]
     PROGPOW_START_TIME = 1635228000
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated peer addresses for the Firo cryptocurrency, enhancing network connectivity and peer discovery.
	- Added multiple peer configurations to the ElectrumX server settings for improved connection options.

- **Bug Fixes**
	- Improved clarity in connection protocols by specifying service types (SSL and TCP) for peer addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->